### PR TITLE
Update addWatchlistItem.md

### DIFF
--- a/Services/EtpContent/POST/addWatchlistItem.md
+++ b/Services/EtpContent/POST/addWatchlistItem.md
@@ -4,7 +4,7 @@ addWatchlistItem
 #### Add a series to your watchlist.
 
 ```http
-POST /content/v2/${account_uuid}/watchlist
+POST /content/v2/discover/${account_uuid}/watchlist
 
 # Request Headers
 Content-Type: application/json


### PR DESCRIPTION
It seems that Crunchyroll changed the location of its `mark_as_watched` endpoint.