### PR TITLE
Updated playback documentation

### DIFF
--- a/Services/Play/GET/getMusicPlayStream.md
+++ b/Services/Play/GET/getMusicPlayStream.md
@@ -4,7 +4,7 @@ getMusicPlayStream
 #### Get music stream.
 
 ```http
-GET /v1/music/{contentId}/${android,web}/${phone,firefox}/play
+GET /v1/music/{contentId}/${android,web,tv}/${phone,tablet,android_tv,firefox,chrome}/play
 # Request Headers
 Authorization: Bearer ${TOKEN}
 x-cr-stream-limits: ${true|false}
@@ -12,5 +12,4 @@ x-cr-stream-limits: ${true|false}
 
 | Parameter | Type | Description |
 | --- | --- | --- |
-| queue | `boolean` | Not sure. |
-| ttloverride | `long` | Not sure. |
+| queue | `boolean` | queue=0 adds a instance to the playback sessions. queue=1 adds a instance to the queue sessions. Both are limited according to your subscription. |

--- a/Services/Play/GET/getPlayStream.md
+++ b/Services/Play/GET/getPlayStream.md
@@ -13,4 +13,5 @@ x-cr-stream-limits: ${true|false}
 
 | Parameter | Type | Description |
 | --- | --- | --- |
-| queue | `integer` | queue=0 adds a instance to the playback sessions. queue=1 adds a instance to the queue sessions. Both are limited according to your subscription. |
+| queue | `boolean` | queue=0 adds a instance to the playback sessions. queue=1 adds a instance to the queue sessions. Both are limited according to your subscription. |
+

--- a/Services/Play/GET/getPlayStream.md
+++ b/Services/Play/GET/getPlayStream.md
@@ -4,7 +4,7 @@ getPlayStream
 #### Get stream.
 
 ```http
-GET /v1/${contentId}/${android,web}/${phone,firefox,chrome}/play
+GET /v1/${contentId}/${android,web,tv}/${phone,tablet,android_tv,firefox,chrome}/play
 
 # Request Headers
 Authorization: Bearer ${TOKEN}
@@ -13,5 +13,4 @@ x-cr-stream-limits: ${true|false}
 
 | Parameter | Type | Description |
 | --- | --- | --- |
-| queue | `boolean` | Not sure. |
-| ttloverride | `long` | Not sure. |
+| queue | `integer` | queue=0 adds a instance to the playback sessions. queue=1 adds a instance to the queue sessions. Both are limited according to your subscription. |


### PR DESCRIPTION
I added more informations regarding the queue param and added more endpoints.
I also removed the "ttloverride" param since it isn't used anymore/I never saw it being used.

Also, the "x-cr-stream-limits" header only works on some endpoints nowadays. Maybe adding a disclaimer would help?